### PR TITLE
Create the contact page

### DIFF
--- a/assets/application.css
+++ b/assets/application.css
@@ -182,4 +182,286 @@ h1, h2, h3, h4, h5, h6 {
   outline: 2px solid var(--color-accent);
   outline-offset: 3px;
   box-shadow: 0 0 0 4px var(--color-background), 0 0 0 6px var(--color-accent);
+}
+
+/* Contact Page Styles */
+.contact-page {
+  margin-top: 40px;
+}
+
+.contact-content {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 60px;
+  margin-top: 40px;
+}
+
+@media (max-width: 768px) {
+  .contact-grid {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+}
+
+/* Contact Form Styles */
+.contact-form-wrapper {
+  background: #ffffff;
+  padding: 40px;
+  border-radius: 12px;
+  box-shadow: 0 4px 25px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e8e8e8;
+}
+
+.contact-form-wrapper h2 {
+  color: #00214d;
+  margin-bottom: 15px;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.contact-form-wrapper p {
+  color: #666;
+  margin-bottom: 30px;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* Form Success/Error Messages */
+.form-success {
+  background-color: #d4edda;
+  border: 1px solid #c3e6cb;
+  color: #155724;
+  padding: 15px 20px;
+  border-radius: 8px;
+  margin-bottom: 25px;
+}
+
+.form-errors {
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  color: #721c24;
+  padding: 15px 20px;
+  border-radius: 8px;
+  margin-bottom: 25px;
+}
+
+.form-errors ul {
+  margin: 10px 0 0 20px;
+  padding: 0;
+}
+
+/* Form Fields */
+.contact-form .form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+@media (max-width: 600px) {
+  .contact-form .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.form-field {
+  margin-bottom: 20px;
+}
+
+.form-field label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.form-field input[type="text"],
+.form-field input[type="email"],
+.form-field input[type="tel"],
+.form-field select,
+.form-field textarea {
+  width: 100%;
+  padding: 12px 16px;
+  border: 2px solid #e8e8e8;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  background-color: #ffffff;
+}
+
+.form-field input[type="text"]:focus,
+.form-field input[type="email"]:focus,
+.form-field input[type="tel"]:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.form-field select {
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 12px center;
+  background-repeat: no-repeat;
+  background-size: 16px;
+  padding-right: 40px;
+}
+
+/* Submit Button */
+.contact-form .btn {
+  background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
+  color: white;
+  border: none;
+  padding: 16px 32px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-transform: none;
+  letter-spacing: 0.5px;
+  margin-top: 10px;
+}
+
+.contact-form .btn:hover {
+  background: linear-gradient(135deg, #0056b3 0%, #004085 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0, 123, 255, 0.3);
+}
+
+/* Contact Information Styles */
+.contact-info-wrapper {
+  background: #f8f9fa;
+  padding: 40px;
+  border-radius: 12px;
+  border: 1px solid #e8e8e8;
+}
+
+.contact-info-wrapper h2 {
+  color: #00214d;
+  margin-bottom: 30px;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.contact-info {
+  margin-bottom: 40px;
+}
+
+.contact-item {
+  margin-bottom: 30px;
+  padding-bottom: 25px;
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.contact-item:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.contact-item h3 {
+  color: #00214d;
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.contact-item p {
+  color: #666;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.contact-item a {
+  color: #007bff;
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.contact-item a:hover {
+  color: #0056b3;
+  text-decoration: underline;
+}
+
+/* Expertise Section */
+.expertise-info {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  border: 1px solid #e8e8e8;
+}
+
+.expertise-info h3 {
+  color: #00214d;
+  margin-bottom: 20px;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.expertise-info ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.expertise-info li {
+  position: relative;
+  padding: 8px 0 8px 25px;
+  color: #666;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.expertise-info li:last-child {
+  border-bottom: none;
+}
+
+.expertise-info li::before {
+  content: '✓';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  color: #28a745;
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+/* Section Header */
+.section-header {
+  margin-bottom: 20px;
+}
+
+.section-header h1 {
+  color: #00214d;
+  margin-bottom: 15px;
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  .section-header h1 {
+    font-size: 2rem;
+  }
+  
+  .contact-form-wrapper,
+  .contact-info-wrapper {
+    padding: 30px 20px;
+  }
+  
+  .page-width {
+    padding: 0 15px;
+  }
 } 

--- a/sections/main-contact.liquid
+++ b/sections/main-contact.liquid
@@ -1,0 +1,312 @@
+{% render 'breadcrumb' %}
+
+<div class="page-width">
+  <div class="section-header text-center">
+    <h1>{{ page.title }}</h1>
+    {% if section.settings.page_subtitle != blank %}
+      <p class="page-subtitle">{{ section.settings.page_subtitle | escape }}</p>
+    {% endif %}
+  </div>
+  
+  <div class="contact-page">
+    <div class="contact-content">
+      {% if page.content != blank %}
+        <div class="rte">
+          {{ page.content }}
+        </div>
+      {% endif %}
+      
+      <div class="contact-grid">
+        <!-- Contact Form -->
+        <div class="contact-form-wrapper">
+          <h2>{{ section.settings.form_title | default: 'Send Us a Message' }}</h2>
+          <p>{{ section.settings.form_description | default: 'Our audio experts are here to help you find the perfect solution.' }}</p>
+          
+          {% form 'contact' %}
+            {% if form.posted_successfully? %}
+              <div class="form-success">
+                <p>{{ section.settings.success_message | default: 'Thank you for contacting us. We\'ll get back to you within 24 hours.' }}</p>
+              </div>
+            {% endif %}
+            
+            {% if form.errors %}
+              <div class="form-errors">
+                <p>{{ 'contact.form.error_heading' | t }}</p>
+                <ul>
+                  {% for field in form.errors %}
+                    <li>
+                      {% if field == 'form' %}
+                        {{ form.errors.messages[field] }}
+                      {% else %}
+                        {{ form.errors.translated_fields[field] | capitalize }} {{ form.errors.messages[field] }}
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+            
+            <div class="contact-form">
+              <div class="form-row">
+                <div class="form-field">
+                  <label for="ContactFormName">{{ 'contact.form.name' | t }} *</label>
+                  <input type="text" id="ContactFormName" name="contact[name]" value="{% if form.name %}{{ form.name }}{% elsif customer %}{{ customer.name }}{% endif %}" required>
+                </div>
+                <div class="form-field">
+                  <label for="ContactFormEmail">{{ 'contact.form.email' | t }} *</label>
+                  <input type="email" id="ContactFormEmail" name="contact[email]" value="{% if form.email %}{{ form.email }}{% elsif customer %}{{ customer.email }}{% endif %}" required>
+                </div>
+              </div>
+              
+              <div class="form-field">
+                <label for="ContactFormPhone">{{ 'contact.form.phone' | t }}</label>
+                <input type="tel" id="ContactFormPhone" name="contact[phone]" value="{% if form.phone %}{{ form.phone }}{% elsif customer %}{{ customer.phone }}{% endif %}">
+              </div>
+              
+              <div class="form-field">
+                <label for="ContactFormSubject">{{ section.settings.subject_label | default: 'Subject' }}</label>
+                <select id="ContactFormSubject" name="contact[subject]">
+                  <option value="">{{ section.settings.subject_placeholder | default: 'Select a topic' }}</option>
+                  <option value="Product Inquiry">Product Inquiry</option>
+                  <option value="Technical Support">Technical Support</option>
+                  <option value="Installation Services">Installation Services</option>
+                  <option value="Returns & Exchanges">Returns & Exchanges</option>
+                  <option value="General Inquiry">General Inquiry</option>
+                </select>
+              </div>
+              
+              <div class="form-field">
+                <label for="ContactFormMessage">{{ 'contact.form.message' | t }} *</label>
+                <textarea id="ContactFormMessage" name="contact[body]" rows="6" required>{% if form.body %}{{ form.body }}{% endif %}</textarea>
+              </div>
+              
+              <button type="submit" class="btn btn-primary">
+                {{ section.settings.submit_button_text | default: 'Send Message' }}
+              </button>
+            </div>
+          {% endform %}
+        </div>
+        
+        <!-- Contact Information -->
+        <div class="contact-info-wrapper">
+          <h2>{{ section.settings.info_title | default: 'Get in Touch' }}</h2>
+          
+          <div class="contact-info">
+            {% if section.settings.show_address and section.settings.address != blank %}
+              <div class="contact-item">
+                <h3>{{ section.settings.address_title | default: 'Visit Our Store' }}</h3>
+                <p>{{ section.settings.address | escape | newline_to_br }}</p>
+              </div>
+            {% endif %}
+            
+            {% if section.settings.show_phone and section.settings.phone != blank %}
+              <div class="contact-item">
+                <h3>{{ section.settings.phone_title | default: 'Call Us' }}</h3>
+                <p><a href="tel:{{ section.settings.phone | remove: ' ' | remove: '-' | remove: '(' | remove: ')' }}">{{ section.settings.phone | escape }}</a></p>
+              </div>
+            {% endif %}
+            
+            {% if section.settings.show_email and section.settings.email != blank %}
+              <div class="contact-item">
+                <h3>{{ section.settings.email_title | default: 'Email Us' }}</h3>
+                <p><a href="mailto:{{ section.settings.email | escape }}">{{ section.settings.email | escape }}</a></p>
+              </div>
+            {% endif %}
+            
+            {% if section.settings.show_hours and section.settings.hours != blank %}
+              <div class="contact-item">
+                <h3>{{ section.settings.hours_title | default: 'Store Hours' }}</h3>
+                <p>{{ section.settings.hours | escape | newline_to_br }}</p>
+              </div>
+            {% endif %}
+          </div>
+          
+          {% if section.settings.show_expertise %}
+            <div class="expertise-info">
+              <h3>{{ section.settings.expertise_title | default: 'Our Expertise' }}</h3>
+              <ul>
+                <li>{{ section.settings.expertise_1 | default: 'Hi-Fi Audio Systems' }}</li>
+                <li>{{ section.settings.expertise_2 | default: 'Home Theatre Installation' }}</li>
+                <li>{{ section.settings.expertise_3 | default: 'Professional Audio Consultation' }}</li>
+                <li>{{ section.settings.expertise_4 | default: 'Custom Audio Solutions' }}</li>
+              </ul>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Contact Page",
+  "settings": [
+    {
+      "type": "text",
+      "id": "page_subtitle",
+      "label": "Page subtitle"
+    },
+    {
+      "type": "header",
+      "content": "Contact Form"
+    },
+    {
+      "type": "text",
+      "id": "form_title",
+      "label": "Form title",
+      "default": "Send Us a Message"
+    },
+    {
+      "type": "textarea",
+      "id": "form_description",
+      "label": "Form description",
+      "default": "Our audio experts are here to help you find the perfect solution."
+    },
+    {
+      "type": "text",
+      "id": "subject_label",
+      "label": "Subject field label",
+      "default": "Subject"
+    },
+    {
+      "type": "text",
+      "id": "subject_placeholder",
+      "label": "Subject field placeholder",
+      "default": "Select a topic"
+    },
+    {
+      "type": "text",
+      "id": "submit_button_text",
+      "label": "Submit button text",
+      "default": "Send Message"
+    },
+    {
+      "type": "text",
+      "id": "success_message",
+      "label": "Success message",
+      "default": "Thank you for contacting us. We'll get back to you within 24 hours."
+    },
+    {
+      "type": "header",
+      "content": "Contact Information"
+    },
+    {
+      "type": "text",
+      "id": "info_title",
+      "label": "Contact info title",
+      "default": "Get in Touch"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_address",
+      "label": "Show address",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "address_title",
+      "label": "Address title",
+      "default": "Visit Our Store"
+    },
+    {
+      "type": "textarea",
+      "id": "address",
+      "label": "Address",
+      "info": "Store address with line breaks"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_phone",
+      "label": "Show phone",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "phone_title",
+      "label": "Phone title",
+      "default": "Call Us"
+    },
+    {
+      "type": "text",
+      "id": "phone",
+      "label": "Phone number"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_email",
+      "label": "Show email",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "email_title",
+      "label": "Email title",
+      "default": "Email Us"
+    },
+    {
+      "type": "text",
+      "id": "email",
+      "label": "Email address"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_hours",
+      "label": "Show store hours",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "hours_title",
+      "label": "Hours title",
+      "default": "Store Hours"
+    },
+    {
+      "type": "textarea",
+      "id": "hours",
+      "label": "Store hours",
+      "info": "Store hours with line breaks"
+    },
+    {
+      "type": "header",
+      "content": "Expertise Section"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_expertise",
+      "label": "Show expertise section",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "expertise_title",
+      "label": "Expertise title",
+      "default": "Our Expertise"
+    },
+    {
+      "type": "text",
+      "id": "expertise_1",
+      "label": "Expertise item 1",
+      "default": "Hi-Fi Audio Systems"
+    },
+    {
+      "type": "text",
+      "id": "expertise_2",
+      "label": "Expertise item 2",
+      "default": "Home Theatre Installation"
+    },
+    {
+      "type": "text",
+      "id": "expertise_3",
+      "label": "Expertise item 3",
+      "default": "Professional Audio Consultation"
+    },
+    {
+      "type": "text",
+      "id": "expertise_4",
+      "label": "Expertise item 4",
+      "default": "Custom Audio Solutions"
+    }
+  ]
+}
+{% endschema %}

--- a/templates/page.contact.json
+++ b/templates/page.contact.json
@@ -1,0 +1,36 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-contact",
+      "settings": {
+        "page_subtitle": "Expert audio consultation and support for all your hi-fi needs",
+        "form_title": "Get Expert Audio Advice",
+        "form_description": "Whether you're looking for a complete system or have technical questions, our audio specialists are here to help you achieve the perfect sound.",
+        "submit_button_text": "Send Message",
+        "success_message": "Thank you for contacting CHT Solutions. One of our audio experts will get back to you within 24 hours.",
+        "info_title": "Visit Our Audio Showroom",
+        "show_address": true,
+        "address_title": "Visit Our Store",
+        "address": "123 Audio Street\nSuite 456\nNew York, NY 10001",
+        "show_phone": true,
+        "phone_title": "Call Our Experts",
+        "phone": "(555) 123-HIFI",
+        "show_email": true,
+        "email_title": "Email Us",
+        "email": "info@chtsolutions.com",
+        "show_hours": true,
+        "hours_title": "Store Hours",
+        "hours": "Monday - Friday: 10am - 7pm\nSaturday: 10am - 6pm\nSunday: 12pm - 5pm",
+        "show_expertise": true,
+        "expertise_title": "Our Expertise",
+        "expertise_1": "High-End Hi-Fi Systems",
+        "expertise_2": "Home Theatre Design & Installation",
+        "expertise_3": "Vintage Audio Restoration",
+        "expertise_4": "Custom Acoustics Solutions"
+      }
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
A comprehensive contact page was implemented for the Shopify audio store.

*   A new section, `sections/main-contact.liquid`, was created.
    *   This section includes a professional contact form with client-side validation and audio-specific subject options.
    *   It also features configurable contact information (address, phone, email, store hours) and an "Our Expertise" section.
    *   The design is responsive, adapting to various screen sizes.
*   A new template, `templates/page.contact.json`, was created.
    *   This JSON template pre-configures the `main-contact` section with default content tailored for an audio store, including sample contact details and expertise areas.
*   The stylesheet `assets/application.css` was updated.
    *   Extensive CSS rules were added to style the contact page elements, ensuring a clean, modern, and responsive layout consistent with the existing theme aesthetics. This includes styling for the form, input fields, buttons, and information display.

The changes provide a fully functional and customizable contact page, ready for use within the Shopify admin.